### PR TITLE
core: fix type error in `sodium/src/node.ts`

### DIFF
--- a/packages/sodium/src/node.ts
+++ b/packages/sodium/src/node.ts
@@ -386,7 +386,7 @@ function from_hex(input: string): Uint8Array {
 }
 
 function to_string(input: Uint8Array): string {
-  return Buffer.from(input, input.byteOffset, input.byteLength).toString(
+  return Buffer.from(input.buffer, input.byteOffset, input.byteLength).toString(
     "utf-8"
   );
 }


### PR DESCRIPTION
Fix type error in `sodium/src/node.ts`:

```
src/node.ts(389,22): error TS2345: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>'.
  Type 'Uint8Array<ArrayBufferLike>' is missing the following properties from type 'ArrayBuffer': maxByteLength, resizable, resize, detached, and 2 more.
```