### PR TITLE
core: fix type error in `filehandle.ts`

### DIFF
--- a/packages/streamable-fs/src/filehandle.ts
+++ b/packages/streamable-fs/src/filehandle.ts
@@ -83,7 +83,7 @@ export default class FileHandle {
     for (let i = from; i < from + length; ++i) {
       const array = await this.readChunk(i);
       if (!array) throw new Error(`No data found for chunk at offset ${i}.`);
-      blobParts.push(array.buffer);
+      blobParts.push(new Uint8Array(array.buffer));
     }
     return new Blob(blobParts, { type: this.file.type });
   }


### PR DESCRIPTION
Fix type error in `filehandle.ts`

```
Argument of type 'ArrayBufferLike' is not assignable to parameter of type 'BlobPart'.
  Type 'SharedArrayBuffer' is not assignable to type 'BlobPart'.
    Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLengthts(2345)
```